### PR TITLE
Fixing Import error on freshly cloned repo

### DIFF
--- a/site-personalization/paid_content/main/urls.py
+++ b/site-personalization/paid_content/main/urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path
 
-import views
+from articles import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
  File "/Users/roma/Desktop/netology/dj-homeworks/site-personalization/paid_content/main/urls.py", line 20, in <module>
    import views
ModuleNotFoundError: No module named 'views'