### PR TITLE
Update requirements.txt

### DIFF
--- a/databases_2/m2m-relations/requirements.txt
+++ b/databases_2/m2m-relations/requirements.txt
@@ -1,2 +1,3 @@
 Django==3.1.2
 psycopg2-binary==2.8.6
+Pillow==8.3.2


### PR DESCRIPTION
To use models.ImageField in models.py, the Pillow library is required.